### PR TITLE
Update peer dependency for @midival/core in package.json to be compatible with versions >=0.1.0 <0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@midival/core": "^0.0.17",
+    "@midival/core": "^0.0.17 || ^0.1.0",
     "midi": "^2.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Currently, when trying to install `0.1.0` of this module along with `@midival/core 0.1.0` or newer, the following error appears:

```
npm ERR! Could not resolve dependency:
npm ERR! peer @midival/core@"^0.0.17" from @midival/node@0.1.0
npm ERR! node_modules/@midival/node
npm ERR!   dev @midival/node@"0.1.0" from the root project
```

According to https://github.com/npm/node-semver/tree/v7.6.0?tab=readme-ov-file#caret-ranges-123-025-004 - a version caret `^0.0.17` would only be able to denote ranges `>=0.0.17 <0.0.18`, rather than `>=0.0.17 <1.0.0`, as the range would only take into account up to the left-most non-zero digit.

`@midival/node 0.1.0` according to the release notes is compatible with `0.1.x` of `@midival/core`, so we would need an additional peer dependency version of `^0.1.0` to capture it.

Running `npm install` with `--legacy-peer-deps` is a workaround until this change gets merged in.