### PR TITLE
feat: migrating to jzz from midi

### DIFF
--- a/.changeset/tiny-apricots-allow.md
+++ b/.changeset/tiny-apricots-allow.md
@@ -1,0 +1,5 @@
+---
+"@midival/node": minor
+---
+
+changing engine to jzz (instead of midi package)

--- a/examples/midi_in.ts
+++ b/examples/midi_in.ts
@@ -1,11 +1,12 @@
 import { MIDIVal } from "@midival/core";
 import {NodeMIDIAccess} from "../src/index";
-import * as midi from "midi";
 import { version as versionMidivalCore } from "@midival/core/package.json";
 import { version as versionMidivalNode } from "../package.json";
+import { MIDIValInput } from "@midival/core";
+import { MIDIValOutput } from "@midival/core";
 
 
-const nodeAccess = new NodeMIDIAccess(midi);
+const nodeAccess = new NodeMIDIAccess();
 MIDIVal.configureAccessObject(nodeAccess);
 console.log("------------------------");
 console.log("MIDIVal - Listing inputs")
@@ -15,13 +16,28 @@ console.log("------------------------");
 console.log();
 MIDIVal.connect()
 .then(access => {
+    console.log('ACCESS', access)
     access.inputs.forEach(device => {
         console.log("[    input     ]", `${device.name} (${device.id})`);
     });
 
-    setTimeout(() => {
-        nodeAccess.createVirtualInputPort("HELLO WORLD");
-    }, 1200);
+    const myInput = access.inputs.find(i => i.name === 'Launchpad Pro Standalone Port')
+    const myOutput = access.outputs.find(i => i.name === 'Launchpad Pro Standalone Port')
+    if (myInput && myOutput) {
+        const output = new MIDIValOutput(myOutput)
+        const launchpad = new MIDIValInput(myInput)
+        launchpad.onAllNoteOn(note => {
+            if (note.velocity < 1) {
+                return
+            }
+            console.log('NOTE ON', note)
+            output.sendNoteOn(note.note, note.velocity)
+        })
+    }
+
+    // setTimeout(() => {
+    //     nodeAccess.createVirtualInputPort("HELLO WORLD");
+    // }, 1200);
 });
 
 MIDIVal.onInputDeviceConnected(device => {

--- a/examples/midi_out.ts
+++ b/examples/midi_out.ts
@@ -1,11 +1,10 @@
 import { MIDIVal } from "@midival/core";
 import {NodeMIDIAccess} from "../src/index";
-import * as midi from "midi";
 
 import { version as versionMidivalCore } from "@midival/core/package.json";
 import { version as versionMidivalNode } from "../package.json";
 
-const nodeAccess = new NodeMIDIAccess(midi, {
+const nodeAccess = new NodeMIDIAccess({
     watchTimeout: 1000,
 });
 console.log("------------------------");
@@ -21,9 +20,9 @@ MIDIVal.connect()
         console.log("[    output     ]", `${device.name} (${device.id})`);
     });
 
-    setTimeout(() => {
-        nodeAccess.createVirtualOutputPort("HELLO WORLD");
-    }, 1200);
+    // setTimeout(() => {
+    //     // nodeAccess.createVirtualOutputPort("HELLO WORLD");
+    // }, 1200);
 });
 
 MIDIVal.onOutputDeviceConnected(device => {

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@midival/core": "^0.0.17",
-    "@midival/node": "^0.0.5",
-    "midi": "^2.0.0"
+    "@midival/node": "^0.0.5"
   },
   "devDependencies": {
     "ts-node": "^10.8.1"

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -86,13 +86,6 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-bindings@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -103,28 +96,10 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
-midi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/midi/-/midi-2.0.0.tgz#5035dd0d0c4b381eeb6e9202c785ce81221d0c7a"
-  integrity sha512-HyCLWa+ET8Aqfu/NxdNkxfCx0EfCJrcZgKuhrY4c9UgkfxRt3ChM7RP1oC5vJf7ALXyuAG47jqr5yUlvSodTPQ==
-  dependencies:
-    bindings "~1.5.0"
-    nan "^2.14.2"
-
-nan@^2.14.2:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
-  integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
 
 ts-node@^10.8.1:
   version "10.8.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "deploy": "gh-pages -d docs"
   },
   "dependencies": {
-    "@hypersphere/omnibus": "^0.1.4"
+    "@hypersphere/omnibus": "^0.1.4",
+    "jzz": "^1.7.9"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@hypersphere/omnibus':
     specifier: ^0.1.4
     version: 0.1.4
+  jzz:
+    specifier: ^1.7.9
+    version: 1.8.0
 
 devDependencies:
   '@changesets/cli':
@@ -1344,6 +1347,10 @@ packages:
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
+
+  /@types/webmidi@2.0.10:
+    resolution: {integrity: sha512-4RmTFMB6mN2h8XbJa1x3cOs9IOkXvFyHGcPUpUvWfmATuKg/J+dsFiMVgCE2EkpS+/8a8AP2tE3rQT1mLG7vEg==}
+    dev: false
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -2744,6 +2751,11 @@ packages:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
+  /jazz-midi@1.7.9:
+    resolution: {integrity: sha512-c8c4BBgwxdsIr1iVm53nadCrtH7BUlnX3V95ciK/gbvXN/ndE5+POskBalXgqlc/r9p2XUbdLTrgrC6fou5p9w==}
+    engines: {node: '>=10.0.0'}
+    dev: false
+
   /jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3196,6 +3208,13 @@ packages:
     optionalDependencies:
       graceful-fs: 4.2.10
     dev: true
+
+  /jzz@1.8.0:
+    resolution: {integrity: sha512-mkEdizFQB3gIk9NzwIsbsKdXtu+t2uL9dCldU0AKct8YK9t5XT68V5IgZ0opfk16FkFXB0QA0Q+IEJEn7M0MQg==}
+    dependencies:
+      '@types/webmidi': 2.0.10
+      jazz-midi: 1.7.9
+    dev: false
 
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}

--- a/src/NodeMIDIAccess.ts
+++ b/src/NodeMIDIAccess.ts
@@ -5,10 +5,6 @@ import {
   IMIDIOutput,
   UnregisterCallback,
 } from "@midival/core";
-// import {
-//   type InputStateChangeCallback,
-//   type OutputStateChangeCallback,
-// } from "@midival/core";
 import { NodeMIDIInput } from "./NodeMIDIInput";
 import { NodeMIDIOutput } from "./NodeMIDIOutput";
 import { VirtualNodeMIDIInput } from "./VirtualNodeMIDIInput";
@@ -30,9 +26,9 @@ const defaultOptions: NodeMidiOptions = {
 };
 
 interface Events {
-  input_connected: [NodeMIDIInput];
+  input_connected: [IMIDIInput];
   input_disconnected: [IMIDIInput];
-  output_conntected: [NodeMIDIOutput];
+  output_conntected: [IMIDIOutput];
   output_disconnected: [IMIDIOutput];
 }
 
@@ -63,35 +59,35 @@ class NodeMIDIAccess implements IMIDIAccess {
     this._options = options;
   }
 
-  // private watchInputs() {
-  //   if (this.isWatchingInputs) {
-  //     return;
-  //   }
-  //   if (!this._options.watchTimeout) {
-  //     return;
-  //   }
-  //   this.isWatchingInputs = true;
-  //   let prevInputs = this.inputs;
-  //   const checkChanges = () => {
-  //     const inputs = this.inputs;
-  //     inputs.forEach((input) => {
-  //       const pastInput = prevInputs.find((pIn) => pIn.name === input.name);
-  //       if (!pastInput) {
-  //         this._bus.trigger("input_connected", input);
-  //       }
-  //     });
-  //     prevInputs.forEach((prevIn, idx) => {
-  //       const newInp = inputs.find((nIn) => nIn.name === prevIn.name);
-  //       if (!newInp) {
-  //         this._bus.trigger("input_disconnected", prevIn);
-  //         this.midiInputs.delete(prevIn.name);
-  //       }
-  //     });
-  //     prevInputs = this.inputs;
-  //     setTimeout(checkChanges, this._options.watchTimeout);
-  //   };
-  //   setTimeout(checkChanges, this._options.watchTimeout);
-  // }
+  private watchInputs() {
+    if (this.isWatchingInputs) {
+      return;
+    }
+    if (!this._options.watchTimeout) {
+      return;
+    }
+    this.isWatchingInputs = true;
+    let prevInputs = this.inputs;
+    const checkChanges = () => {
+      const inputs = this.inputs;
+      inputs.forEach((input) => {
+        const pastInput = prevInputs.find((pIn) => pIn.name === input.name);
+        if (!pastInput) {
+          this._bus.trigger("input_connected", input);
+        }
+      });
+      prevInputs.forEach((prevIn, idx) => {
+        const newInp = inputs.find((nIn) => nIn.name === prevIn.name);
+        if (!newInp) {
+          this._bus.trigger("input_disconnected", prevIn);
+          this.midiInputs.delete(prevIn.name);
+        }
+      });
+      prevInputs = this.inputs;
+      setTimeout(checkChanges, this._options.watchTimeout);
+    };
+    setTimeout(checkChanges, this._options.watchTimeout);
+  }
 
   private watchOutputs() {
     if (this.isWatchingOutputs) {
@@ -127,11 +123,11 @@ class NodeMIDIAccess implements IMIDIAccess {
   }
 
   onInputConnected(callback: any): UnregisterCallback {
-    // this.watchInputs();
+    this.watchInputs();
     return this._bus.on("input_connected", callback);
   }
   onInputDisconnected(callback: any): UnregisterCallback {
-    // this.watchInputs();
+    this.watchInputs();
     return this._bus.on("input_disconnected", callback);
   }
   onOutputConnected(callback): UnregisterCallback {

--- a/src/NodeMIDIAccess.ts
+++ b/src/NodeMIDIAccess.ts
@@ -9,13 +9,7 @@ import { NodeMIDIInput } from "./NodeMIDIInput";
 import { NodeMIDIOutput } from "./NodeMIDIOutput";
 import { VirtualNodeMIDIInput } from "./VirtualNodeMIDIInput";
 import { VirtualNodeMIDIOutput } from "./VirtualNodeMIDIOutput";
-import { randomUUID } from "crypto";
 import jzz = require("jzz");
-
-const range = (i: number) =>
-  Array.apply(null, Array(i)).map(function (_, i) {
-    return i;
-  });
 
 export interface NodeMidiOptions {
   watchTimeout: number;
@@ -50,12 +44,14 @@ class NodeMIDIAccess implements IMIDIAccess {
   private isWatchingInputs: boolean = false;
   private isWatchingOutputs: boolean = false;
 
+  private midi: ReturnType<typeof jzz>
   static getMidiLibrary() {
     return this._midi;
   }
 
   constructor(options: NodeMidiOptions = defaultOptions) {
-    NodeMIDIAccess._midi = jzz();
+    this.midi = jzz();
+    NodeMIDIAccess._midi = this.midi
     this._options = options;
   }
 
@@ -99,6 +95,7 @@ class NodeMIDIAccess implements IMIDIAccess {
     this.isWatchingOutputs = true;
     let prevOutputs = this.outputs;
     const checkChanges = () => {
+      this.midi.refresh()
       const outputs = this.outputs;
       outputs.forEach((output, idx) => {
         const pastOutput = prevOutputs.find((pIn) => pIn.name === output.name);
@@ -143,9 +140,6 @@ class NodeMIDIAccess implements IMIDIAccess {
 
   async connect(): Promise<void> {
     const data = jzz.info()
-    console.log(data)
-     
-    console.log('DATA', data)
     return Promise.resolve();
   }
   createVirtualInputPort(name: string): VirtualNodeMIDIInput {

--- a/src/NodeMIDIInput.spec.ts
+++ b/src/NodeMIDIInput.spec.ts
@@ -18,14 +18,15 @@ const getMockInput = (): MockInput => {
 describe("NodeMIDIInput", () => {
     it("should properly instantiate", () => {
         const mock: Input = getMockInput();
-        const input = new NodeMIDIInput("1234", "hello", mock);
+        const input = new NodeMIDIInput("1234", "hello", 'man');
         expect(input.id).toEqual("1234");
         expect(input.name).toEqual("hello");
+        expect(input.manufacturer).toEqual('man')
     });
 
     it("should properly connect and trigger messages", () => {
         const mock: Input = getMockInput();
-        const input = new NodeMIDIInput("1234", "hello", mock);
+        const input = new NodeMIDIInput("1234", "hello", 'man');
         const fn = jest.fn();
         input.onMessage(fn);
         expect(mock.on).toBeCalledTimes(1);

--- a/src/NodeMIDIOutput.spec.ts
+++ b/src/NodeMIDIOutput.spec.ts
@@ -8,8 +8,9 @@ const getMockOutput = (): Output => ({
 describe("NodeMIDIOutput", () => {
     it("should properly instantiate", () => {
         const mock: Output = getMockOutput();
-        const output = new NodeMIDIOutput("1234", "hello", mock);
+        const output = new NodeMIDIOutput("1234", "hello", 'man');
         expect(output.id).toEqual("1234");
         expect(output.name).toEqual("hello");
+        expect(output.manufacturer).toEqual('man')
     });
 })

--- a/src/NodeMIDIOutput.ts
+++ b/src/NodeMIDIOutput.ts
@@ -1,30 +1,22 @@
 import { IMIDIOutput } from "@midival/core";
-import type { Output } from "midi";
+import jzz = require("jzz");
 
 export class NodeMIDIOutput implements IMIDIOutput {
-    private _id: string;
-    private _name: string;
-    private _output: Output;
+    constructor(public readonly id: string, public readonly name: string, public readonly manufacturer: string) {
 
-    constructor(id: string, name: string, output: Output) {
-        this._id = id;
-        this._name = name;
-        this._output = output;
     }
+
+    private _out
+    get output() {
+        this._out = jzz().openMidiOut(this.name)
+        if (this._out) {
+            return this._out
+        }
+    }
+
     send(data: Uint8Array | number[]): void {
-        console.log(this._output);
-        this._output.sendMessage([data[0], data[1], data[2]]);
+        console.log(`SENDING DATA TO ${this.name}: ${data.join(', ')}`)
+        this.output.then(o => o.send(...data))
     }
 
-    get id(): string {
-        return String(this._id);
-    }
-
-    get name(): string {
-        return this._name;
-    }
-
-    get manufacturer(): string {
-        return "Unknown";
-    }
 }

--- a/src/VirtualNodeMIDIInput.ts
+++ b/src/VirtualNodeMIDIInput.ts
@@ -2,16 +2,13 @@ import { randomUUID } from "crypto";
 import type { Input } from "midi";
 import { NodeMIDIAccess } from "./NodeMIDIAccess";
 import { NodeMIDIInput } from "./NodeMIDIInput";
+import jzz = require("jzz");
 
 export class VirtualNodeMIDIInput extends NodeMIDIInput {
     private _midiInput: Input;
-    constructor(name: string) {
-        const input = new (NodeMIDIAccess.getMidiLibrary()).Input();
-        input.openVirtualPort(name);
-        super(randomUUID(), name, input);
-        this._midiInput = input;
+    constructor(name: string, manufacturer?: string) {
+        super('dsad', name, manufacturer)
     }
     disconnect() {
-        this._midiInput.closePort();
     }
 }

--- a/src/VirtualNodeMIDIOutput.ts
+++ b/src/VirtualNodeMIDIOutput.ts
@@ -5,11 +5,8 @@ import { NodeMIDIOutput } from "./NodeMIDIOutput";
 
 export class VirtualNodeMIDIOutput extends NodeMIDIOutput {
     private _midiOutput: Output;
-    constructor(name: string) {
-        const output: Output = new (NodeMIDIAccess.getMidiLibrary()).Output();
-        output.openVirtualPort(name);
-        super(randomUUID(), name, output);
-        this._midiOutput = output;
+    constructor(name: string, manufacturer?: string) {
+        super(randomUUID(), name, manufacturer);
     }
     disconnect() {
         this._midiOutput.closePort();


### PR DESCRIPTION
Upgrading library to start using JZZ instead of MIDI package. JZZ, unlike MIDI Node package, is actively developed and supports more environments out of the box.